### PR TITLE
Add "your_project/" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,4 +94,4 @@ We recommend walking through the CIFAR-10 example, which uses Pytorch to impleme
 
 The instructions for running this CNN example are [here.](examples/cifar10/README.md)
 
-The instructions for setting up your own Python project to run through `burst` are [here.](examples/your_example/README.md)
+The instructions for setting up your own Python project to run through `burst` are [here.](examples/your_project/README.md)

--- a/README.md
+++ b/README.md
@@ -93,3 +93,5 @@ The `examples/` folder contains pre-built machine learning examples to help you 
 We recommend walking through the CIFAR-10 example, which uses Pytorch to implement a Convolutional Neural Net (CNN) for image classification on the benchmark CIFAR-10 dataset.  This example also illustrates how to use `burst` to run a Jupyter notebook on a remote GPU, for real-time model building and manipulation on a GPU.
 
 The instructions for running this CNN example are [here.](examples/cifar10/README.md)
+
+The instructions for setting up your own Python project to run through `burst` are [here.](examples/your_example/README.md)

--- a/examples/your_project/.burstignore
+++ b/examples/your_project/.burstignore
@@ -1,0 +1,5 @@
+venv
+.ipynb_checkpoints
+__pycache__
+.git
+

--- a/examples/your_project/.dockerignore
+++ b/examples/your_project/.dockerignore
@@ -1,0 +1,3 @@
+**
+!/Dockerfile*
+!/requirements.txt

--- a/examples/your_project/Dockerfile
+++ b/examples/your_project/Dockerfile
@@ -1,0 +1,9 @@
+FROM nvidia/cuda:10.1-devel-ubuntu18.04
+WORKDIR /home/burst/work
+RUN apt-get update && apt-get install -y python3 python3-dev python3-pip nano fish git curl rclone fuse wget
+RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py  && rm get-pip.py
+RUN pip3 install gputil ipython
+COPY requirements.txt requirements.txt
+RUN pip3 install -r ./requirements.txt
+CMD ["/bin/bash"]
+

--- a/examples/your_project/README.md
+++ b/examples/your_project/README.md
@@ -32,12 +32,28 @@ Make sure you have all supporting data files and *.py files in the directory wit
 
 To run the command line example using burst, use
 
-    burst python3 template.py 
+    burst python3 template.py --verbosity 1
 
 The output should look something like this:
 
 ```
-graves@pescadero ~/g/v/s/b/e/your_project> python template.py
+graves@pescadero ~/g/v/s/b/e/your_project> burst python3 template.py --verbosity 1
+Session: burst-graves
+Waiting for sshd
+Connecting through ssh
+Killing shutdown processes: ['53aaf212b1e6']
+Removing topmost layer
+burst: name burst-graves size g4dn.xlarge image Deep Learning AMI (Ubuntu 18.04) Version 36.0 url 34.222.154.210
+Synchronizing project folders
+building file list ... 
+11 files to consider
+
+sent 306 bytes  received 20 bytes  217.33 bytes/sec
+total size is 31518  speedup is 96.68
+Building docker container
+Running docker container
+
+---------------------OUTPUT-----------------------
 0 * 0 = 0
 1 * 1 = 1
 2 * 2 = 4
@@ -48,8 +64,22 @@ graves@pescadero ~/g/v/s/b/e/your_project> python template.py
 7 * 7 = 49
 8 * 8 = 64
 9 * 9 = 81
-graves@pescadero ~/g/v/s/b/e/your_project>
+----------------------END-------------------------
+Synchronizing folders
+receiving file list ... 
+11 files to consider
+example.png
+       10811 100%   10.31MB/s    0:00:00 (xfer#1, to-check=4/11)
+
+sent 134 bytes  received 356 bytes  326.67 bytes/sec
+total size is 31518  speedup is 64.32
+Scheduling shutdown of VM at 34.222.154.210 for 900 seconds from now
+DONE
+
+graves@pescadero ~/g/v/s/b/e/your_project> 
 ```
+
+YOu can suppress most of the `burst` information by not specifying a `verbosity`, e.g., `burst python3 template.py`.
 
 The first time you run burst, it will spin up a new server.  This will take several minutes.  It takes several more minutes to build the Docker container, as it downloads and installs all the required software and python packages.  On subsequent runs, starting with a running server or a stopped server, this initial set-up time will be negligible.  If you change `requirements.txt` between runs, the Docker container will take some time to rebuild itself on the next `burst` run.
 

--- a/examples/your_project/README.md
+++ b/examples/your_project/README.md
@@ -79,9 +79,9 @@ DONE
 graves@pescadero ~/g/v/s/b/e/your_project> 
 ```
 
-YOu can suppress most of the `burst` information by not specifying a `verbosity`, e.g., `burst python3 template.py`.
+You can suppress most of the `burst` information by not specifying a `verbosity`, e.g., `burst python3 template.py`.
 
-The first time you run burst, it will spin up a new server.  This will take several minutes.  It takes several more minutes to build the Docker container, as it downloads and installs all the required software and python packages.  On subsequent runs, starting with a running server or a stopped server, this initial set-up time will be negligible.  If you change `requirements.txt` between runs, the Docker container will take some time to rebuild itself on the next `burst` run.
+The first time you run `burst`, it will spin up a new server.  This will take several minutes.  It takes several more minutes to build the Docker container, as it downloads and installs all the required software and python packages.  On subsequent runs, starting with a running server or a stopped server, this initial set-up time will be negligible.  If you change `requirements.txt` between runs, the Docker container will take some time to rebuild itself on the next `burst` run.
 
 When `burst` has finished running your project, it will automatically transfer any modified files back to your local directory and close the connection.  Once a `burst` connection has been closed for > 15 minutes, it will stop the remote server so that you will not be paying for it.
 

--- a/examples/your_project/README.md
+++ b/examples/your_project/README.md
@@ -1,0 +1,77 @@
+# burst example: Setting up your own Python project
+=======
+
+# Required files
+
+Every Python `burst` project requires the following files:
+
+* `.dockerignore`
+* `.burstignore`
+* `Dockerfile`
+* `requirements.txt`
+
+Template versions of all of these files are included in this example directory.  For most pure python projects, the `Dockerfile`, `.dockerignore`, and `.burstignore` files included here will work out of the box.  The only file you will need to modify is the `requirements.txt`.
+
+# Setting up your `requirements.txt` file
+
+This file needs to specify the correct version of each python package you need to install in order to run your project.  These will typically be the packages that you import at the top of your python script or Jupyter notebook.
+
+If you used `pip` to install packages, either in a virtual environment or directly into your main programming environment, you can see which version of each package is installed by running
+
+	pip freeze
+
+at the command line.  Specify these versions in your `requirements.txt` file, following the example format included in the template `requirements.txt` here.  
+
+If you use `conda` to manage your python packages, you may need to look elsewhere in your system to find the correct version numbers for your packages (please update this README with instructions on how to find `conda` package versioning info!)
+
+# Setting up your project
+
+Make sure you have all supporting data files and *.py files in the directory with your project.  `burst` will transfer all files in the directory from which it is called (except for those specified in the `.burstignore`!).
+
+# Running command line examples using burst
+
+To run the command line example using burst, use
+
+    burst python3 template.py 
+
+The output should look something like this:
+
+```
+graves@pescadero ~/g/v/s/b/e/your_project> python template.py
+0 * 0 = 0
+1 * 1 = 1
+2 * 2 = 4
+3 * 3 = 9
+4 * 4 = 16
+5 * 5 = 25
+6 * 6 = 36
+7 * 7 = 49
+8 * 8 = 64
+9 * 9 = 81
+graves@pescadero ~/g/v/s/b/e/your_project>
+```
+
+The first time you run burst, it will spin up a new server.  This will take several minutes.  It takes several more minutes to build the Docker container, as it downloads and installs all the required software and python packages.  On subsequent runs, starting with a running server or a stopped server, this initial set-up time will be negligible.  If you change `requirements.txt` between runs, the Docker container will take some time to rebuild itself on the next `burst` run.
+
+When `burst` has finished running your project, it will automatically transfer any modified files back to your local directory and close the connection.  Once a `burst` connection has been closed for > 15 minutes, it will stop the remote server so that you will not be paying for it.
+
+You can inspect the output files that have been transferred back to your local machine.
+
+# Running examples in Jupyter using burst
+
+Sometimes it is useful to be able to have an entire Jupyter notebook running on a GPU, while you are experimenting with a new model, so that the run time is fast while you are developing.  `burst` can support remote Jupyter notebooks for real-time model experimentation on a GPU.  
+
+To run a remote Jupyter server through `burst`, use
+
+    burst -p 8899 jupyter lab --ip 0.0.0.0 --port 8899 --allow-root
+    
+Make sure you use a port number that is not already in use (if the port is in use, you will get a non-transparent error message!)  The screen will then display a URL, which will look something like
+
+    http://0.0.0.0:8899/lab?token=f60aaf215e2bd8a92015f732388e16b6407181aaca4a1a9a
+
+Paste this URL into a new browser window.  This will load a JupyterLab window that is running on the remote `burst` server.
+
+Edit and run the Jupyter notebook, just as you would on a local Jupyter server.  
+
+NOTE: When you are done, *you must manually close the Jupyter server* by returning to the window where you launched it and hitting Ctl-C, then responding 'y' to shutdown the server.  *If you leave the Jupyter server running, you will continue to pay for the remote server, even if no code is being executed.  `burst` will not automatically stop a remote Jupyter server.*
+

--- a/examples/your_project/README.md
+++ b/examples/your_project/README.md
@@ -79,7 +79,7 @@ DONE
 graves@pescadero ~/g/v/s/b/e/your_project> 
 ```
 
-You can suppress most of the `burst` information by not specifying a `verbosity`, e.g., `burst python3 template.py`.
+You can suppress most of the `burst` information by not specifying a `verbosity`, e.g., `burst python3 template.py`.  You can get maximum verbosity with `--verbosity 127`.
 
 The first time you run `burst`, it will spin up a new server.  This will take several minutes.  It takes several more minutes to build the Docker container, as it downloads and installs all the required software and python packages.  On subsequent runs, starting with a running server or a stopped server, this initial set-up time will be negligible.  If you change `requirements.txt` between runs, the Docker container will take some time to rebuild itself on the next `burst` run.
 

--- a/examples/your_project/Template.ipynb
+++ b/examples/your_project/Template.ipynb
@@ -1,0 +1,88 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "bronze-schedule",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "communist-telephone",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = np.arange(10) \n",
+    "y = x**2 "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "applicable-compilation",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.PathCollection at 0x7fa328b95668>"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAD4CAYAAAD1jb0+AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8li6FKAAARy0lEQVR4nO3db4hd933n8fdnRzKZpLsdOxmENUpWhpgJpiFWOgRnXUJr2StnW+IhhOD0D6IY9CRtk7aosfqkLCwkQaVpHpSCsNsVbEiTuqpssiWqUR2WwuLu2HKr2K6w68aJRrI17WaabHbYyOp3H8wZSxqPozuae+fOb+b9AnPP+d17db8crA9Hv/M755uqQpLUnn8z7AIkSdfHAJekRhngktQoA1ySGmWAS1Kjtq3nj73jHe+o3bt3r+dPSlLznnrqqX+qqvHl4+sa4Lt372ZmZmY9f1KSmpfk5ZXGnUKRpEYZ4JLUKANckhplgEtSowxwSWrUuq5CkaSt5PipWQ6fOMO5+QV2jo1ycN8k03sm+vbnG+CSNADHT81y6NhpFi5eAmB2foFDx04D9C3EnUKRpAE4fOLM6+G9ZOHiJQ6fONO33+gpwJP8epJnk3wzyZeTvCXJLUmeTPJikq8kuaFvVUlS487NL6xq/HpcM8CTTAC/BkxV1U8AI8D9wOeBL1TVu4HvAg/0rSpJatzOsdFVjV+PXqdQtgGjSbYBbwXOA3cBj3TvHwWm+1aVJDXu4L5JRrePXDU2un2Eg/sm+/Yb1wzwqpoFfhf4NovB/S/AU8B8Vb3WfewssOKsfJIDSWaSzMzNzfWnakna4Kb3TPDZj76XibFRAkyMjfLZj753fVehJLkRuA+4BZgH/hS4t9cfqKojwBGAqakpG3BK2jKm90z0NbCX62UK5W7gH6tqrqouAseAO4GxbkoFYBcwO6AaJUkr6CXAvw3ckeStSQLsBZ4DngA+1n1mP/DoYEqUJK2klznwJ1m8WPk0cLr7zhHgM8BvJHkReDvw8ADrlCQt09OdmFX1O8DvLBt+CfhA3yuSJPXEOzElqVEGuCQ1ygCXpEYZ4JLUKANckhplgEtSowxwSWqUAS5JjTLAJalRBrgkNcoAl6RGGeCS1CgDXJIaZYBLUqMMcElq1DUDPMlkkmeu+O97ST6d5KYkjyd5oXu9cT0KliQt6qUjz5mqur2qbgd+Evi/wJ8DDwInq+pW4GS3L0laJ6udQtkL/ENVvcxip/qj3fhRYLqfhUmSfrTVBvj9wJe77R1Vdb7bfgXYsdIXkhxIMpNkZm5u7jrLlCQt13OAJ7kB+Ajwp8vfq6oCaqXvVdWRqpqqqqnx8fHrLlSSdLXVnIF/GHi6ql7t9l9NcjNA93qh38VJkt7cagL8E1yePgF4DNjfbe8HHu1XUZKka+spwJO8DbgHOHbF8OeAe5K8ANzd7UuS1sm2Xj5UVT8A3r5s7J9ZXJUiSRoC78SUpEYZ4JLUKANckhplgEtSowxwSWqUAS5JjeppGaEkteT4qVkOnzjDufkFdo6NcnDfJNN7JoZdVt8Z4JI2leOnZjl07DQLFy8BMDu/wKFjpwE2XYg7hSJpUzl84szr4b1k4eIlDp84M6SKBscAl7SpnJtfWNV4ywxwSZvKzrHRVY23zACXtKkc3DfJ6PaRq8ZGt49wcN/kkCoaHC9iStpUli5UugpFkho0vWdiUwb2ck6hSFKjem3oMJbkkSR/n+T5JB9MclOSx5O80L3eOOhiJUmX9XoG/kXg61X1HuB9wPPAg8DJqroVONntS5LWyTUDPMmPAx8CHgaoqh9W1TxwH3C0+9hRYHpQRUqS3qiXM/BbgDngj5OcSvJQ1yNzR1Wd7z7zCrBjUEVKkt6olwDfBrwf+MOq2gP8gGXTJVVVQK305SQHkswkmZmbm1trvZKkTi8BfhY4W1VPdvuPsBjorya5GaB7vbDSl6vqSFVNVdXU+Ph4P2qWJNFDgFfVK8B3kizdxrQXeA54DNjfje0HHh1IhZKkFfV6I8+vAl9KcgPwEvDLLIb/V5M8ALwMfHwwJUqSVtJTgFfVM8DUCm/t7W85kqReeSemJDXKAJekRhngktQoA1ySGmWAS1KjDHBJapQBLkmNMsAlqVEGuCQ1ygCXpEYZ4JLUKANckhplgEtSowxwSWqUAS5JjTLAJalRPTV0SPIt4PvAJeC1qppKchPwFWA38C3g41X13cGUKUlabjVn4D9TVbdX1VJnngeBk1V1K3CSZZ3qJUmD1WtPzJXcB/x0t30U+AbwmTXWI6lxx0/NcvjEGc7NL7BzbJSD+yaZ3jMx7LI2pV7PwAv4yyRPJTnQje2oqvPd9ivAjpW+mORAkpkkM3Nzc2ssV9JGdvzULIeOnWZ2foECZucXOHTsNMdPzQ67tE2p1wD/qap6P/Bh4JNJPnTlm1VVLIb8G1TVkaqaqqqp8fHxtVUraUM7fOIMCxcvXTW2cPESh0+cGVJFm1tPAV5Vs93rBeDPgQ8Arya5GaB7vTCoIiW14dz8wqrGtTbXDPAkb0vyb5e2gf8IfBN4DNjffWw/8OigipTUhp1jo6sa19r0cga+A/jrJH8L/A3w36vq68DngHuSvADc3e1L2sIO7ptkdPvIVWOj20c4uG9ySBVtbtdchVJVLwHvW2H8n4G9gyhKUpuWVpu4CmV9rGUZoSS9wfSeCQN7nXgrvSQ1ygCXpEYZ4JLUKANckhplgEtSowxwSWqUAS5JjTLAJalRBrgkNcoAl6RGGeCS1CgDXJIaZYBLUqMMcElqVM8BnmQkyakkX+v2b0nyZJIXk3wlyQ2DK1OStNxqzsA/BTx/xf7ngS9U1buB7wIP9LMwSdKP1lOAJ9kF/CzwULcf4C7gke4jR4HpQRQoSVpZr2fgvw/8FvCv3f7bgfmqeq3bPwus2IIjyYEkM0lm5ubm1lSsJOmyXrrS/xxwoaqeup4fqKojVTVVVVPj4+PX80dIklbQS0/MO4GPJPlPwFuAfwd8ERhLsq07C98FzA6uTEnSctc8A6+qQ1W1q6p2A/cDf1VVvwA8AXys+9h+4NGBVSlJeoO1rAP/DPAbSV5kcU784f6UJEnqRS9TKK+rqm8A3+i2XwI+0P+SJEm98E5MSWrUqs7AJW1cx0/NcvjEGc7NL7BzbJSD+yaZ3rPi6l5tEga4tAkcPzXLoWOnWbh4CYDZ+QUOHTsNYIhvYk6hSJvA4RNnXg/vJQsXL3H4xJkhVaT1YIBLm8C5+YVVjWtzMMClTWDn2OiqxrU5GODSJnBw3ySj20euGhvdPsLBfZNDqkjrwYuY0iawdKHSVShbiwEubRLTeyYM7C3GKRRJapQBLkmNMsAlqVEGuCQ1ygCXpEYZ4JLUKANckhrVS1PjtyT5myR/m+TZJP+5G78lyZNJXkzylSQ3DL5cSdKSXs7A/x9wV1W9D7gduDfJHcDngS9U1buB7wIPDK5MSdJyvTQ1rqr6P93u9u6/Au4CHunGjwLTA6lQkrSinubAk4wkeQa4ADwO/AMwX1WvdR85C6x4D2+SA0lmkszMzc31o2ZJEj0GeFVdqqrbgV0sNjJ+T68/UFVHqmqqqqbGx8evs0xJ0nKrWoVSVfPAE8AHgbEkSw/D2gXM9rk2SdKP0MsqlPEkY932KHAP8DyLQf6x7mP7gUcHVaQk6Y16eZzszcDRJCMsBv5Xq+prSZ4D/iTJfwFOAQ8PsE5J0jLXDPCq+jtgzwrjL7E4Hy5JGgLvxJSkRhngktQoA1ySGmVPTGmNjp+atZmwhsIAl9bg+KlZDh07zcLFSwDMzi9w6NhpAENcA+cUirQGh0+ceT28lyxcvMThE2eGVJG2EgNcWoNz8wurGpf6yQCX1mDn2OiqxqV+MsClNTi4b5LR7SNXjY1uH+HgvskhVaStxIuY0hosXah0FYqGwQCX1mh6z4SBraFwCkWSGmWAS1KjDHBJapQBLkmN6qUjzzuTPJHkuSTPJvlUN35TkseTvNC93jj4ciVJS3o5A38N+M2qug24A/hkktuAB4GTVXUrcLLblyStk2sGeFWdr6qnu+3vs9gPcwK4DzjafewoMD2oIiVJb7SqOfAku1lsr/YksKOqzndvvQLseJPvHEgyk2Rmbm5uDaVKkq7Uc4An+THgz4BPV9X3rnyvqgqolb5XVUeqaqqqpsbHx9dUrCTpsp4CPMl2FsP7S1V1rBt+NcnN3fs3AxcGU6IkaSW9rEIJ8DDwfFX93hVvPQbs77b3A4/2vzxJ0pvp5VkodwK/BJxO8kw39tvA54CvJnkAeBn4+GBKlCSt5JoBXlV/DeRN3t7b33IkSb3yTkxJapSPk1Wz7Aavrc4AV5PsBi85haJG2Q1eMsDVKLvBSwa4GmU3eMkAV6PsBi95EVONshu8ZICrYXaD11bnFIokNcoAl6RGGeCS1CgDXJIaZYBLUqMMcElqVC8def4oyYUk37xi7KYkjyd5oXu9cbBlSpKW6+UM/L8C9y4bexA4WVW3Aie7fUnSOrpmgFfV/wD+97Lh+4Cj3fZRYLrPdUmSruF678TcUVXnu+1XgB1v9sEkB4ADAO9617uu8+e00dhMQRq+NV/ErKoC6ke8f6Sqpqpqanx8fK0/pw1gqZnC7PwCxeVmCsdPzQ67NGlLud4AfzXJzQDd64X+laSNzmYK0sZwvQH+GLC/294PPNqfctQCmylIG0Mvywi/DPxPYDLJ2SQPAJ8D7knyAnB3t68twmYK0sZwzYuYVfWJN3lrb59rUSMO7pu8qqEw2ExBGgafB65Vs5mCtDEY4LouNlOQhs9noUhSowxwSWqUAS5JjTLAJalRXsRsjM8gkbTEAG/I0jNIltZfLz2DBDDEpS3IKZSG+AwSSVcywBviM0gkXckAb4jPIJF0JQO8IQf3TTK6feSqMZ9BIm1dXsRsiM8gkXQlA7xHG2X5ns8gkbTEAO+By/ckbUTOgffA5XuSNqI1nYEnuRf4IjACPFRVfe/MsxGmLly+J2kjuu4z8CQjwB8AHwZuAz6R5LZ+FQYbp/u5y/ckbURrmUL5APBiVb1UVT8E/gS4rz9lLdooUxcu35O0Ea0lwCeA71yxf7Ybu0qSA0lmkszMzc2t6gc2ytTF9J4JPvvR9zIxNkqAibFRPvvR93oBU9JQDXwVSlUdAY4ATE1N1Wq+u3NslNkVwnoYUxcu35O00azlDHwWeOcV+7u6sb5x6kKS3txazsD/F3BrkltYDO77gZ/vS1Ud7zyUpDd33QFeVa8l+RXgBIvLCP+oqp7tW2Udpy4kaWVrmgOvqr8A/qJPtUiSVsE7MSWpUQa4JDXKAJekRhngktSoVK3q3pq1/VgyB7x8nV9/B/BPfSyndR6PyzwWV/N4XLZZjsW/r6rx5YPrGuBrkWSmqqaGXcdG4fG4zGNxNY/HZZv9WDiFIkmNMsAlqVEtBfiRYRewwXg8LvNYXM3jcdmmPhbNzIFLkq7W0hm4JOkKBrgkNaqJAE9yb5IzSV5M8uCw6xmWJO9M8kSS55I8m+RTw65pI0gykuRUkq8Nu5ZhSjKW5JEkf5/k+SQfHHZNw5Tk17u/J99M8uUkbxl2Tf224QN8PZonN+Q14Der6jbgDuCTW/hYXOlTwPPDLmID+CLw9ap6D/A+tvAxSTIB/BowVVU/weIjr+8fblX9t+EDnHVontyKqjpfVU93299n8S/oln5YepJdwM8CDw27lmFK8uPAh4CHAarqh1U1P9yqhm4bMJpkG/BW4NyQ6+m7FgK8p+bJW02S3cAe4MnhVjJ0vw/8FvCvwy5kyG4B5oA/7qaTHkrytmEXNSxVNQv8LvBt4DzwL1X1l8Otqv9aCHAtk+THgD8DPl1V3xt2PcOS5OeAC1X11LBr2QC2Ae8H/rCq9gA/ALby9aIbWfyX+i3ATuBtSX5xuFX1XwsBPvDmyS1Jsp3F8P5SVR0bdj1DdifwkSTfYnFq7a4k/224JQ3NWeBsVS39i+wRFgN9q7ob+Meqmquqi8Ax4D8Muaa+ayHAX2+enOQGFi9EPDbkmoYiSVic43y+qn5v2PUMW1UdqqpdVbWbxf8v/qqqNt1ZVi+q6hXgO0kmu6G9wHNDLGnYvg3ckeSt3d+bvWzCi7pr6om5HtareXIj7gR+CTid5Jlu7Le73qTSrwJf6k50XgJ+ecj1DE1VPZnkEeBpFldvnWIT3lbvrfSS1KgWplAkSSswwCWpUQa4JDXKAJekRhngktQoA1ySGmWAS1Kj/j+7nYPFK9cIQgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.scatter(x, y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "banned-injury",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/your_project/requirements.txt
+++ b/examples/your_project/requirements.txt
@@ -1,0 +1,4 @@
+numpy==1.18.1
+matplotlib==3.1.2
+jupyterlab==1.2.7
+gpuinfo==1.0.0a7

--- a/examples/your_project/template.py
+++ b/examples/your_project/template.py
@@ -1,0 +1,12 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+x = np.arange(10)
+y = x**2 
+
+for i in range(len(x)):
+    print('{} * {} = {}'.format(x[i], x[i], y[i]))
+
+plt.scatter(x, y)
+plt.savefig('example.png')
+


### PR DESCRIPTION
Added an folder `examples/your_project/` with templates to walk users through setting up their own Python project to use with burst.

Includes templates of the required files:

- Dockerfile
- .dockerignore
- .burstignore
- requirements.txt

Also includes a template *.py and Jupyter notebook for them to modify. 

Instructions for setting up the user project are in `examples/your_project/README.md`

I also modified the main burst README.md to have a link to the `examples/your_project/README.md` at the end.