### PR TITLE
stdout: use "killing" for docker, not "terminate"

### DIFF
--- a/burst/burst_cli.py
+++ b/burst/burst_cli.py
@@ -297,7 +297,7 @@ if __name__ == "__main__":
         if not url:
             print ("No process running")
         else:
-            vvprint (f"Terminating Docker process on {url}")
+            vvprint (f"Killing Docker process on {url}")
             tunnel, _ = ssh_tunnel(url, args.sshuser, args.portmap, args.dockerdport)
             vvprint ("Tunnel:", tunnel)
             cmd = ["docker", "-H localhost:%s" % args.dockerdport, "ps", "--format", '{{json .}}']
@@ -309,12 +309,12 @@ if __name__ == "__main__":
             else:
                 try:
                     did = json.loads(out)
-                    yes = input(f"Terminating Docker process {did['ID']}, are you sure? (y/n)")
+                    yes = input(f"Killing Docker process {did['ID']}, are you sure? (y/n)")
                     if yes == 'y':
                         cmd = f"docker -H localhost:{args.dockerdport} stop {did['ID']}"
                         vvprint (cmd)
                         os.system(cmd)
-                        print ("Process terminated")
+                        print ("Process killed")
                     else:
                         print("Aborted")
                 except:


### PR DESCRIPTION
Changed `burst_cli.py` so that stdout feedback to the user uses "kill" terminology for ending docker processes, instead of "terminate" (which is used for servers).

_NOTE: Only print() statement strings were changed in this PR, no code logic._